### PR TITLE
Add methods to subscribe and publish from and to a channel

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import { expire } from "./query/expire";
 import { update } from "./query/update";
 import { reload } from "./query/reload";
 import { connect } from "./query/connect";
+import { publish } from "./pubsub/publish";
+import { subscribe } from "./pubsub/subscribe";
 
 import { createConnection } from "./database";
 
@@ -30,3 +32,5 @@ exports("expire", expire);
 exports("update", update);
 exports("reload", reload);
 exports("connect", connect);
+exports("publish", publish);
+exports("subscribe", subscribe);

--- a/src/pubsub/publish.ts
+++ b/src/pubsub/publish.ts
@@ -1,0 +1,20 @@
+import { redisClient } from "../database";
+import { resourceName } from "..";
+
+/**
+ * Publishes a value to a specific channel in Redis.
+ *
+ * @param channel - The channel to send to.
+ * @param value - The value to publish for the channel.
+ * @param callback - An optional callback function to handle the result of the publish operation.
+ * @returns The result of the publish operation, or the result passed to the callback function if provided.
+ */
+export async function publish( channel: string, value: string, callback: (data: number) => any) {
+    ScheduleResourceTick(resourceName);
+    try {
+        const result = await redisClient.publish(channel, value);
+        return callback ? callback(result) : result;
+    } catch (error: any) {
+        return console.error("Redis error while publishing data: " + error.message);
+    }
+}

--- a/src/pubsub/subscribe.ts
+++ b/src/pubsub/subscribe.ts
@@ -1,0 +1,40 @@
+import { RedisClientType } from "redis";
+import { redisClient } from "../database";
+import { resourceName } from "..";
+
+type Subscription = {
+    redisClient: RedisClientType;
+    callbacks: ((data: string) => void)[];
+};
+
+const subscribers: Record<string, Subscription> = {};
+
+/**
+ * Subscribes to a channel to receive values to a callback from Redis.
+ *
+ * @param channel - The channel to receive from.
+ * @param callback - A callback function to handle the result of the subscribe operation.
+ */
+export async function subscribe(channel: string, callback: (data: string) => void) {
+    ScheduleResourceTick(resourceName);
+    try {
+        if (!Object.prototype.hasOwnProperty.call(subscribers, channel)) {
+            subscribers[channel] = {
+                redisClient: await redisClient.duplicate(),
+                callbacks: [],
+            };
+
+            await subscribers[channel].redisClient.connect();
+            await subscribers[channel].redisClient.subscribe(
+                channel,
+                (data: string) => {
+                    subscribers[channel].callbacks.forEach((callback) => callback(data));
+                }
+            );
+        }
+
+        subscribers[channel].callbacks.push(callback);
+    } catch (error: any) {
+        return console.error("Redis error while subscribing channel: " + error.message);
+    }
+}


### PR DESCRIPTION
This allows to utilize redis pubsub channels.
To subscribe to a channel you can use the `subscribe` export:
```lua
exports['redisdb']:subscribe('channel', function(data)
    print(data)
end)
```

To publish to a channel you can use the `publish` export:
```lua
exports['redisdb']:publish('channel', "very nice content")
```